### PR TITLE
Fix jar of eyes recipe.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -251,7 +251,7 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'witchcraft:bottle_eyes',
 	recipe = {
-		{'default:bucket_water'},
+		{'bucket:bucket_water'},
 		{'vessels:drinking_glass'},
 	}
 })


### PR DESCRIPTION
You put `default:bucket_water` when it should be `bucket:bucket_water`. This fixes the displayed recipe in mods like `craftguide` (https://github.com/minetest-mods/craftguide).