### PR TITLE
Silence light_source warnings.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -3797,7 +3797,7 @@ minetest.register_node("witchcraft:pentagram", {
 	paramtype = "light",
 	paramtype2 = "wallmounted",
 	sunlight_propagates = false,	
-	light_source = 50,
+	light_source = 14,
 	walkable = false,
 	is_ground_content = true,
 	selection_box = {
@@ -3840,7 +3840,7 @@ minetest.register_node("witchcraft:portal", {
 	paramtype = "light",
 	paramtype2 = "wallmounted",
 	sunlight_propagates = false,	
-	light_source = 50,
+	light_source = 14,
 	walkable = false,
 	is_ground_content = true,
 	selection_box = {


### PR DESCRIPTION
The maximum light_source is 14. This silences these two warnings.
```
WARNING[Main]: Node 'light_source' value exceeds maximum, limiting to maximum: witchcraft:pentagram
WARNING[Main]: Node 'light_source' value exceeds maximum, limiting to maximum: witchcraft:portal
```